### PR TITLE
Explicitly direct people to chat channels

### DIFF
--- a/scripts/general-redirect.coffee
+++ b/scripts/general-redirect.coffee
@@ -94,7 +94,7 @@ module.exports = (robot) ->
 
   # redirect user to the specified channel
   redirectTo = (res, channel) ->
-    res.reply "Please redirect your question to ##{channel}"
+    res.reply "Please redirect your question to chat channel ##{channel}"
     robot.logger.info "*** Redirected to #{channel} ***"
 
   # should the bot respond? returns true/false


### PR DESCRIPTION
A number of people have started using channel names as hashtags on the mailing lists. I want to make it obvious it is an actual chat channel, not a hashtag.