### PR TITLE
Undo circleCI filtering

### DIFF
--- a/scripts/circle-ci-notifications.coffee
+++ b/scripts/circle-ci-notifications.coffee
@@ -12,10 +12,6 @@ CIRCLE_NOTIFICATION_PREFIX = 'circle-ci-notify'
 
 module.exports = (robot) ->
   robot.router.post '/hubot/circleci', (req, res) ->
-    if ! /https:\/\/circleci.com\/gh\/hyperledger(-labs)?\/.*/.test(payload.build_url)
-      robot.logger.debug "Not a hyperledger build '#{payload.build_url}'"
-      return res.send "Not a hyperledger build"
-
     payload = req.body.payload
     branch = payload.branch.toLowerCase()
     repo = payload.reponame.toLowerCase()


### PR DESCRIPTION
The code intended to mask out non-hyperledger notifications actually filtered
out all notificaitons.  Undo that change and deal with too many.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>