### PR TITLE
ci: make branch notification filter slightly less restrictive

### DIFF
--- a/scripts/circle-ci-notifications.coffee
+++ b/scripts/circle-ci-notifications.coffee
@@ -2,7 +2,7 @@ watchers = {
   "besu": {
     channel: "besu-contributors"
     regexes: [
-      /^master$/
+      /^master/
       /^release-.*/
     ]
   }


### PR DESCRIPTION
Since the branch filters were made more strict in #38, it doesn't seem that build failures in besu's `master` branch are relayed to the `besu-contributors` channel. I'm not 100% sure that this filter was the cause, but since release branch notifications are working, I'm hoping that removing the end of line metachar will fix it.